### PR TITLE
Limit number of pages visited

### DIFF
--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -57,6 +57,22 @@ public class CrawlConfig {
     private int maxPagesToFetch = -1;
 
     /**
+     * Maximum number of pages to visit For unlimited number of pages, this
+     * parameter should be set to -1
+     */
+    private int maxPagesToVisit = -1;
+
+    /**
+     * Links are followed in a random manner, or in the order they were discovered?
+     */
+    private boolean randomized = false;
+
+    /**
+     * Number of maximum random links to follow
+     */
+    private int maxRandomLinksToFollowPerPage = -1;
+
+    /**
      * user-agent string that is used for representing your crawler to web
      * servers. See http://en.wikipedia.org/wiki/User_agent for more details
      */
@@ -277,6 +293,18 @@ public class CrawlConfig {
         return maxPagesToFetch;
     }
 
+    public int getMaxPagesToVisit() {
+        return maxPagesToVisit;
+    }
+
+    public boolean isRandomized() {
+        return randomized;
+    }
+
+    public int getMaxRandomLinksToFollowPerPage() {
+        return maxRandomLinksToFollowPerPage;
+    }
+
     /**
      * Maximum number of pages to fetch For unlimited number of pages, this parameter should be
      * set to -1
@@ -285,6 +313,18 @@ public class CrawlConfig {
      */
     public void setMaxPagesToFetch(int maxPagesToFetch) {
         this.maxPagesToFetch = maxPagesToFetch;
+    }
+
+    public void setMaxPagesToVisit(int maxPagesToVisit) {
+        this.maxPagesToVisit = maxPagesToVisit;
+    }
+
+    public void setRandomized(boolean randomized) {
+        this.randomized = randomized;
+    }
+
+    public void setMaxRandomLinksToFollowPerPage(int maxRandomLinksToFollowPerPage) {
+        this.maxRandomLinksToFollowPerPage = maxRandomLinksToFollowPerPage;
     }
 
     /**

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlController.java
@@ -284,7 +284,7 @@ public class CrawlController extends Configurable {
                                     if (!someoneIsWorking) {
                                         if (!shuttingDown) {
                                             long queueLength = frontier.getQueueLength();
-                                            if (queueLength > 0) {
+                                            if (queueLength > 0 && !frontier.visitedEnoughPages()) {
                                                 continue;
                                             }
                                             logger.info(
@@ -294,7 +294,7 @@ public class CrawlController extends Configurable {
                                                 " seconds to make sure...");
                                             sleep(config.getThreadShutdownDelaySeconds());
                                             queueLength = frontier.getQueueLength();
-                                            if (queueLength > 0) {
+                                            if (queueLength > 0 && !frontier.visitedEnoughPages()) {
                                                 continue;
                                             }
                                         }

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/Counters.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/frontier/Counters.java
@@ -45,6 +45,7 @@ public class Counters extends Configurable {
     public static class ReservedCounterNames {
         public static final String SCHEDULED_PAGES = "Scheduled-Pages";
         public static final String PROCESSED_PAGES = "Processed-Pages";
+        public static final String VISITED_PAGES = "Visited-Pages";
     }
 
     private static final String DATABASE_NAME = "Statistics";

--- a/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
+++ b/crawler4j/src/main/java/edu/uci/ics/crawler4j/parser/Parser.java
@@ -142,6 +142,8 @@ public class Parser extends Configurable {
                         outgoingUrls.add(webURL);
                         urlCount++;
                         if (urlCount > config.getMaxOutgoingLinksToFollow()) {
+                            logger.info("Number of links found in {} exceeds the maximum.",
+                                        page.getWebURL());
                             break;
                         }
                     }


### PR DESCRIPTION
Allow limiting number of pages visited.
Choose to randomize and only select a few links in a page to follow.
These are useful if you want to use Crawler4j to drive a (randomized) content testing, rather than finding everything.